### PR TITLE
Improve client/server tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 GO_LINT=$(shell which golangci-lint 2> /dev/null || echo '')
 GO_LINT_URI=github.com/golangci/golangci-lint/cmd/golangci-lint@latest
 
+.PHONY: all
+all: lint test
+
 .PHONY: lint
 lint:
 	$(if $(GO_LINT), ,go install $(GO_LINT_URI))
@@ -9,8 +12,4 @@ lint:
 
 .PHONY: test
 test:
-	go test -race ./...
-
-.PHONY: default
-default: lint test
-
+	go test -race -count 1 ./...


### PR DESCRIPTION
- Tests must not call *testing.T methods after the test function returns. Use a sync.WaitGroup to ensure that server handler functions complete before tests return.
- Simplify the code by merging cstHandler into cstServer.
- Convert cstHandler/cstServer embedded fields to plain fields. The explicit field names improve readability.
- cstServer had a mix of unexported and exported fields. Unexport all fields for consistency.