### PR TITLE
Fix subprotocol selection

### DIFF
--- a/server.go
+++ b/server.go
@@ -101,8 +101,8 @@ func checkSameOrigin(r *http.Request) bool {
 func (u *Upgrader) selectSubprotocol(r *http.Request, responseHeader http.Header) string {
 	if u.Subprotocols != nil {
 		clientProtocols := Subprotocols(r)
-		for _, serverProtocol := range u.Subprotocols {
-			for _, clientProtocol := range clientProtocols {
+		for _, clientProtocol := range clientProtocols {
+			for _, serverProtocol := range u.Subprotocols {
 				if clientProtocol == serverProtocol {
 					return clientProtocol
 				}

--- a/server_test.go
+++ b/server_test.go
@@ -54,6 +54,36 @@ func TestIsWebSocketUpgrade(t *testing.T) {
 	}
 }
 
+func TestSubProtocolSelection(t *testing.T) {
+	upgrader := Upgrader{
+		Subprotocols: []string{"foo", "bar", "baz"},
+	}
+
+	r := http.Request{Header: http.Header{"Sec-Websocket-Protocol": {"foo", "bar"}}}
+	s := upgrader.selectSubprotocol(&r, nil)
+	if s != "foo" {
+		t.Errorf("Upgrader.selectSubprotocol returned %v, want %v", s, "foo")
+	}
+
+	r = http.Request{Header: http.Header{"Sec-Websocket-Protocol": {"bar", "foo"}}}
+	s = upgrader.selectSubprotocol(&r, nil)
+	if s != "bar" {
+		t.Errorf("Upgrader.selectSubprotocol returned %v, want %v", s, "bar")
+	}
+
+	r = http.Request{Header: http.Header{"Sec-Websocket-Protocol": {"baz"}}}
+	s = upgrader.selectSubprotocol(&r, nil)
+	if s != "baz" {
+		t.Errorf("Upgrader.selectSubprotocol returned %v, want %v", s, "baz")
+	}
+
+	r = http.Request{Header: http.Header{"Sec-Websocket-Protocol": {"quux"}}}
+	s = upgrader.selectSubprotocol(&r, nil)
+	if s != "" {
+		t.Errorf("Upgrader.selectSubprotocol returned %v, want %v", s, "empty string")
+	}
+}
+
 var checkSameOriginTests = []struct {
 	ok bool
 	r  *http.Request


### PR DESCRIPTION
Changed the order of subprotocol selection to prefer client order.

See discussion at gorilla/websocket/pull/823.