### PR TITLE
Improve WriteControl timeout

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -438,23 +438,24 @@ func (c *Conn) WriteControl(messageType int, data []byte, deadline time.Time) er
 		maskBytes(key, 0, buf[6:])
 	}
 
-	d := 1000 * time.Hour
-	if !deadline.IsZero() {
-		d = time.Until(deadline)
+	if deadline.IsZero() {
+		// No timeout for zero time.
+		<-c.mu
+	} else {
+		d := time.Until(deadline)
 		if d < 0 {
 			return errWriteTimeout
 		}
-	}
-
-	select {
-	case <-c.mu:
-	default:
-		timer := time.NewTimer(d)
 		select {
 		case <-c.mu:
-			timer.Stop()
-		case <-timer.C:
-			return errWriteTimeout
+		default:
+			timer := time.NewTimer(d)
+			select {
+			case <-c.mu:
+				timer.Stop()
+			case <-timer.C:
+				return errWriteTimeout
+			}
 		}
 	}
 

--- a/conn_test.go
+++ b/conn_test.go
@@ -148,6 +148,31 @@ func TestFraming(t *testing.T) {
 	}
 }
 
+func TestConcurrencyWriteControl(t *testing.T) {
+	const message = "this is a ping/pong messsage"
+	loop := 10
+	workers := 10
+	for i := 0; i < loop; i++ {
+		var connBuf bytes.Buffer
+
+		wg := sync.WaitGroup{}
+		wc := newTestConn(nil, &connBuf, true)
+
+		for i := 0; i < workers; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				if err := wc.WriteControl(PongMessage, []byte(message), time.Now().Add(time.Second)); err != nil {
+					t.Errorf("concurrently wc.WriteControl() returned %v", err)
+				}
+			}()
+		}
+
+		wg.Wait()
+		wc.Close()
+	}
+}
+
 func TestControl(t *testing.T) {
 	const message = "this is a ping/pong messsage"
 	for _, isServer := range []bool{true, false} {

--- a/conn_test.go
+++ b/conn_test.go
@@ -148,6 +148,22 @@ func TestFraming(t *testing.T) {
 	}
 }
 
+func TestWriteControlDeadline(t *testing.T) {
+	t.Parallel()
+	message := []byte("hello")
+	var connBuf bytes.Buffer
+	c := newTestConn(nil, &connBuf, true)
+	if err := c.WriteControl(PongMessage, message, time.Time{}); err != nil {
+		t.Errorf("WriteControl(..., zero deadline) = %v, want nil", err)
+	}
+	if err := c.WriteControl(PongMessage, message, time.Now().Add(time.Second)); err != nil {
+		t.Errorf("WriteControl(..., future deadline) = %v, want nil", err)
+	}
+	if err := c.WriteControl(PongMessage, message, time.Now().Add(-time.Second)); err == nil {
+		t.Errorf("WriteControl(..., past deadline) = nil, want timeout error")
+	}
+}
+
 func TestConcurrencyWriteControl(t *testing.T) {
 	const message = "this is a ping/pong messsage"
 	loop := 10


### PR DESCRIPTION
- Reduce use of timer.
- Do not timeout when WriteControl deadline is zero.